### PR TITLE
BE出错时的删除命令修改

### DIFF
--- a/quick_start/Deploy.md
+++ b/quick_start/Deploy.md
@@ -290,7 +290,6 @@ mysql> ALTER SYSTEM ADD BACKEND "host:port";
 如出现错误，需要删除BE节点，应用下列命令：
 
 * `alter system decommission backend "be_host:be_heartbeat_service_port";`
-* `alter system dropp backend "be_host:be_heartbeat_service_port";`
 
 具体参考[扩容缩容](../administration/Scale_up_down.md)。
 <br/>


### PR DESCRIPTION
目前官方文档存在两个删除BE的命令，有的用户以为这两个是一个删除BE的命令，导致出错，不推荐用户使用第二种删除命令，故现在需要删掉