### PR TITLE
Update HLL.md

### DIFF
--- a/sql-reference/sql-statements/data-definition/HLL.md
+++ b/sql-reference/sql-statements/data-definition/HLL.md
@@ -65,6 +65,7 @@ HLL_EMPTY()
 
     create table test_uv(
     dt date,
+    id int,
     uv_set hll hll_union)
     distributed by hash(id) buckets 32;
 


### PR DESCRIPTION
示例中对于test_uv的建表语句中并没有出现id的字段，但是在分桶时有选择这个列作为分桶列，所以在test_uv的建表语句中添加了id字段