### PR TITLE
Update SSB_Benchmarking.md

### DIFF
--- a/benchmarking/SSB_Benchmarking.md
+++ b/benchmarking/SSB_Benchmarking.md
@@ -59,7 +59,7 @@ StarRocks，Apache Druid 和 Clickhouse 部署在相同配置的机器上分别�
 
 ```SQL
 --Q1.1 
-SELECT sum(lo_extendedprice * lo_discount) AS `revenue` 
+SELECT sum(lo_extendedprice * lo_discount) AS revenue 
 FROM lineorder_flat 
 WHERE lo_orderdate >= '1993-01-01' and lo_orderdate <= '1993-12-31' AND lo_discount BETWEEN 1 AND 3 AND lo_quantity < 25; 
 


### PR DESCRIPTION
I want to know why this SQL uses backquotes, or is it just a typo?
I also see it in https://starrocks.com/zh-CN/blog/ssb_flat_2.1.