### PR TITLE
修复导入和查询章节里404的链接

### DIFF
--- a/quick_start/Import_and_query.md
+++ b/quick_start/Import_and_query.md
@@ -86,7 +86,7 @@ StarRocks 支持多种 select 用法，包括：[Join](/sql-reference/sql-statem
 
 ### 函数支持
 
-StarRocks 中支持多种函数，包括：[日期函数](/sql-reference/sql-functions/date-time-functions/)，[地理位置函数](/sql-reference/sql-functions/spatial-functions)，[字符串函数](/sql-reference/sql-functions/string-functions/)，[聚合函数](/sql-reference/sql-functions/aggregate-functions/)，[Bitmap 函数](/sql-reference/sql-functions/bitmap-functions/)，[数组函数](/sql-reference/sql-functions/array-functions/)，[cast 函数](/sql-reference/sql-functions/cast.md)，[hash 函数](/sql-reference/sql-functions/hash-functions/)，[加密函数](/sql-reference/sql-functions/encryption-functions/)，[开窗函数](/using_starrocks/Window_function.md) 等。
+StarRocks 中支持多种函数，包括：[日期函数](/sql-reference/sql-functions/date-time-functions/convert_tz)，[地理位置函数](/sql-reference/sql-functions/spatial-functions/st_astext)，[字符串函数](/sql-reference/sql-functions/string-functions/append_trailing_char_if_absent)，[聚合函数](/sql-reference/sql-functions/aggregate-functions/approx_count_distinct)，[Bitmap 函数](/sql-reference/sql-functions/bitmap-functions/bitmap_and)，[数组函数](/sql-reference/sql-functions/array-functions/array_append)，[cast 函数](/sql-reference/sql-functions/cast.md)，[hash 函数](/sql-reference/sql-functions/hash-functions/murmur_hash3_32)，[加密函数](/sql-reference/sql-functions/encryption-functions/md5)，[窗口函数](/using_starrocks/Window_function.md) 等。
 
 ### 视图，物化视图
 

--- a/quick_start/Import_and_query.md
+++ b/quick_start/Import_and_query.md
@@ -86,7 +86,7 @@ StarRocks 支持多种 select 用法，包括：[Join](/sql-reference/sql-statem
 
 ### 函数支持
 
-StarRocks 中支持多种函数，包括：[日期函数](/sql-reference/sql-functions/date-time-functions/convert_tz)，[地理位置函数](/sql-reference/sql-functions/spatial-functions/st_astext)，[字符串函数](/sql-reference/sql-functions/string-functions/append_trailing_char_if_absent)，[聚合函数](/sql-reference/sql-functions/aggregate-functions/approx_count_distinct)，[Bitmap 函数](/sql-reference/sql-functions/bitmap-functions/bitmap_and)，[数组函数](/sql-reference/sql-functions/array-functions/array_append)，[cast 函数](/sql-reference/sql-functions/cast.md)，[hash 函数](/sql-reference/sql-functions/hash-functions/murmur_hash3_32)，[加密函数](/sql-reference/sql-functions/encryption-functions/md5)，[窗口函数](/using_starrocks/Window_function.md) 等。
+StarRocks 中支持多种函数，包括：[日期函数](/sql-reference/sql-functions/date-time-functions/convert_tz)，[地理位置函数](/sql-reference/sql-functions/spatial-functions/st_astext)，[字符串函数](/sql-reference/sql-functions/string-functions/append_trailing_char_if_absent)，[聚合函数](/sql-reference/sql-functions/aggregate-functions/approx_count_distinct)，[Bitmap 函数](/sql-reference/sql-functions/bitmap-functions/bitmap_and)，[数组函数](/sql-reference/sql-functions/array-functions/array_append)，[cast 函数](/sql-reference/sql-functions/cast.md)，[hash 函数](/sql-reference/sql-functions/hash-functions/murmur_hash3_32)，[加密函数](/sql-reference/sql-functions/encryption-functions/md5.md)，[窗口函数](/using_starrocks/Window_function.md) 等。
 
 ### 视图，物化视图
 

--- a/quick_start/Import_and_query.md
+++ b/quick_start/Import_and_query.md
@@ -86,7 +86,7 @@ StarRocks 支持多种 select 用法，包括：[Join](/sql-reference/sql-statem
 
 ### 函数支持
 
-StarRocks 中支持多种函数，包括：[日期函数](/sql-reference/sql-functions/date-time-functions/convert_tz)，[地理位置函数](/sql-reference/sql-functions/spatial-functions/st_astext)，[字符串函数](/sql-reference/sql-functions/string-functions/append_trailing_char_if_absent)，[聚合函数](/sql-reference/sql-functions/aggregate-functions/approx_count_distinct)，[Bitmap 函数](/sql-reference/sql-functions/bitmap-functions/bitmap_and)，[数组函数](/sql-reference/sql-functions/array-functions/array_append)，[cast 函数](/sql-reference/sql-functions/cast.md)，[hash 函数](/sql-reference/sql-functions/hash-functions/murmur_hash3_32)，[加密函数](/sql-reference/sql-functions/encryption-functions/md5.md)，[窗口函数](/using_starrocks/Window_function.md) 等。
+StarRocks 中支持多种函数，包括：[日期函数](/sql-reference/sql-functions/date-time-functions/convert_tz.md)，[地理位置函数](/sql-reference/sql-functions/spatial-functions/st_astext.md)，[字符串函数](/sql-reference/sql-functions/string-functions/append_trailing_char_if_absent.md)，[聚合函数](/sql-reference/sql-functions/aggregate-functions/approx_count_distinct.md)，[Bitmap 函数](/sql-reference/sql-functions/bitmap-functions/bitmap_and.md)，[数组函数](/sql-reference/sql-functions/array-functions/array_append.md)，[cast 函数](/sql-reference/sql-functions/cast.md)，[hash 函数](/sql-reference/sql-functions/hash-functions/murmur_hash3_32.md)，[加密函数](/sql-reference/sql-functions/encryption-functions/md5.md)，[窗口函数](/using_starrocks/Window_function.md) 等。
 
 ### 视图，物化视图
 


### PR DESCRIPTION
修复文档中：https://docs.starrocks.com/zh-cn/main/quick_start/Import_and_query 不可用的链接