### PR TITLE
[On Hold] Update SSB_Benchmarking.md

### DIFF
--- a/benchmarking/SSB_Benchmarking.md
+++ b/benchmarking/SSB_Benchmarking.md
@@ -91,7 +91,7 @@ ORDER BY year, p_brand;
 --Q2.3 
 SELECT sum(lo_revenue),  year(lo_orderdate) AS year, p_brand 
 FROM lineorder_flat 
-WHERE p_brand = 'MFGR#2239' AND s_region = 'EUROPE' 
+WHERE p_brand = 'MFGR#2339' AND s_region = 'EUROPE' 
 GROUP BY  year,  p_brand 
 ORDER BY year, p_brand; 
 


### PR DESCRIPTION
I think we and clickhouse's official website(https://clickhouse.com/docs/en/getting-started/example-datasets/star-schema/) are both wrong. 
The original text in ssb's paper(https://www.cs.umb.edu/~poneil/StarSchemaB.PDF) are as follows:
```
Q2.3 Change p_category = 'MFGR#12' to p_brand1 =
'MFGR#2339' and s_region = 'EUROPE'.

select sum(lo_revenue), d_year, p_brand1
 from lineorder, date, part, supplier
 where lo_orderdate = d_datekey
 and lo_partkey = p_partkey
 and lo_suppkey = s_suppkey
 and p_brand1 = 'MFGR#2221'
 and s_region = 'EUROPE'
 group by d_year, p_brand1
 order by d_year, p_brand1; 
```
Although the paper does not correspond to the front and back, it should at least be MFGR#2339 or MFGR#2221. 
I don't know how MFGR#2239 came from.