### PR TITLE
[Community-P0_maybe] Modify the JDK version in the documentation example to OpenJDK 8

### DIFF
--- a/loading/Flink_cdc_load.md
+++ b/loading/Flink_cdc_load.md
@@ -42,9 +42,9 @@
       java -version
       
       # 如下显示已经安装 java 8
-      java version "1.8.0_301"
-      Java(TM) SE Runtime Environment (build 1.8.0_301-b09)
-      Java HotSpot(TM) 64-Bit Server VM (build 25.301-b09, mixed mode)
+      openjdk version "1.8.0_322"
+      OpenJDK Runtime Environment (Temurin)(build 1.8.0_322-b06)
+      OpenJDK 64-Bit Server VM (Temurin)(build 25.322-b06, mixed mode)
       ```
 
    2. 下载并解压 [Flink](https://flink.apache.org/downloads.html)。本示例使用 Flink 1.14.5。


### PR DESCRIPTION
修改文档示例中的JDK版本为OpenJDK 8。在官网文档中显示Oracle JDK 1.8版本可能是不妥的，Oracle在JDK 1.8.0_211及之后版本将协议从BCL修改为可按照商业用途收费的OTN协议，后续大版本商用仍有风险，直至JDK 17版本(NFTC许可) 才再次可免费商用。