### PR TITLE
[Community-P3] Fix mysql login command

### DIFF
--- a/loading/Flink_cdc_load.md
+++ b/loading/Flink_cdc_load.md
@@ -141,7 +141,7 @@
 
    ```Plain
    -- 连接 MySQL
-   mysql -h xxx.xx.xxx.xx -uroot -p xxxxxx
+   mysql -h xxx.xx.xxx.xx -P 3306 -u root -p
 
    -- 检查是否已经开启 MySQL Binlog，`ON`就表示已开启
    mysql> SHOW VARIABLES LIKE 'log_bin'; 


### PR DESCRIPTION
修正mysql登陆命令。mysql登陆命令中，-h、-P、-u后的空格可要可不要，但-p后的空格不能要，通常是-p后直接跟明文密码或者回车后按提示数据密码。