### PR TITLE
[community-P1] SET_VAR 提示在 MySQL 8.0 以下版本无效

### DIFF
--- a/reference/System_variable.md
+++ b/reference/System_variable.md
@@ -80,7 +80,10 @@ SELECT /*+ SET_VAR(exec_mem_limit = 8589934592) */ name FROM people ORDER BY nam
 SELECT /*+ SET_VAR(query_timeout = 1) */ sleep(3);
 ```
 
-> 注：提示必须以"/*+"开头，并且只能跟随在 SELECT 关键字之后。
+> 注：
+> 1. `SET_VAR` 提示仅支持 MySQL 8.0 之后的版本；
+> 2. 提示必须以"/*+"开头，并且只能跟随在 SELECT 关键字之后。
+
 
 ## 支持的变量
 


### PR DESCRIPTION
`SET_VAR` 为 MySQL 在 8.0 之后的版本引入的 feature: [Variable-Setting Hint Syntax](https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html#optimizer-hints-set-var)。

用户如果使用 8.0 以下客户端连接(包括最新版本 MariaDB)，该提示无法生效，且没有任何报错信息，产生不符合预期的行为。

建议增加相关标注，避免出现误解。