### PR TITLE
[community-P3] MarkDown 格式优化

### DIFF
--- a/sql-reference/sql-statements/data-manipulation/ROUTINE LOAD.md
+++ b/sql-reference/sql-statements/data-manipulation/ROUTINE LOAD.md
@@ -373,11 +373,13 @@ FROM KAFKA
 ```
 
 支持两种 JSON 数据格式：
-1）{"category":"a9jadhx","author":"test","price":895}
-2）[
+
+1）`{"category":"a9jadhx","author":"test","price":895}`
+
+2）`[
 {"category":"a9jadhx","author":"test","price":895},
 {"category":"axdfa1","author":"EvelynWaugh","price":1299}
-]
+]`
 
 ### 示例5：指定 `jsonpaths` 导入 JSON 格式数据
 
@@ -425,14 +427,18 @@ FROM KAFKA
 ```
 
 JSON数据格式:
+```
 [
 {"category":"11","title":"SayingsoftheCentury","price":895,"timestamp":1589191587},
 {"category":"22","author":"2avc","price":895,"timestamp":1589191487},
 {"category":"33","author":"3avc","title":"SayingsoftheCentury","timestamp":1589191387}
 ]
+```
 
 说明：
+
 1）如果 JSON 数据是以数组开始，并且数组中每个对象是一条记录，则需要将 `strip_outer_array` 设置成 `true`，表示展平数组。
+
 2）如果 JSON 数据是以数组开始，并且数组中每个对象是一条记录，在设置 `jsonpaths` 时，ROOT 节点实际上是数组中对象。
 
 ### 示例6：指定根节点 `json_root`
@@ -460,6 +466,7 @@ FROM KAFKA
 ```
 
 JSON 数据格式:
+```
 {
 "RECORDS":[
 {"category":"11","title":"SayingsoftheCentury","price":895,"timestamp":1589191587},
@@ -467,3 +474,4 @@ JSON 数据格式:
 {"category":"33","author":"3avc","title":"SayingsoftheCentury","timestamp":1589191387}
 ]
 }
+```


### PR DESCRIPTION
MarkDown 中，换行需要另起一行，原文如下:

<img width="639" alt="image" src="https://user-images.githubusercontent.com/6762627/197522646-4b0c5ccd-a637-40b4-9ea0-1c3eed1fde79.png">