### PR TITLE
[Community-P3] Modify "INT、INTEGER" to "INT/INTEGER"

### DIFF
--- a/data_source/catalog/hive_catalog.md
+++ b/data_source/catalog/hive_catalog.md
@@ -10,7 +10,7 @@ Hive catalog 是一个外部数据目录 (external catalog)。在 StarRocks 中�
 ## 使用限制
 
 - StarRocks 支持查询如下格式的 Hive 数据：Parquet、ORC 和 CSV。
-- StarRocks 支持查询如下类型的 Hive 数据：TINYINT、SMALLINT、DATE、BOOLEAN、INT、INTEGER、BIGINT、TIMESTAMP、STRING、VARCHAR、CHAR、DOUBLE、FLOAT、DECIMAL 和 ARRAY。注意查询命中不支持的数据类型会报错，不支持的数据类型包括：INTERVAL、BINARY、MAP、 STRUCT 和 UNION。
+- StarRocks 支持查询如下类型的 Hive 数据：TINYINT、SMALLINT、DATE、BOOLEAN、INT/INTEGER、BIGINT、TIMESTAMP、STRING、VARCHAR、CHAR、DOUBLE、FLOAT、DECIMAL 和 ARRAY。注意查询命中不支持的数据类型会报错，不支持的数据类型包括：INTERVAL、BINARY、MAP、 STRUCT 和 UNION。
 - StarRocks 2.4 及以上版本支持使用 [DESC](/sql-reference/sql-statements/Utility/DESCRIBE.md) 语句查看 Hive 表结构。查看时，不支持的数据类型会显示成`unknown`。
 
 ## 前提条件


### PR DESCRIPTION
Hive中INT和INTEGER通常认为是一种类型的两种写法，用INT/INTEGER更合适一些