### PR TITLE
[Community-P3] Delete a description that is suspected to be redundant in the document

### DIFF
--- a/data_source/External_table.md
+++ b/data_source/External_table.md
@@ -188,8 +188,6 @@ StarRocks 支持对 Elasticsearch 表进行谓词下推，把过滤条件推给 
 |  not in   |  bool.must_not + terms   |
 |  esquery   |  ES Query DSL   |
 
-表 1 ：支持的谓词下推列表
-
 <br/>
 
 ### 查询示例


### PR DESCRIPTION
删除ES外表文档中的"表 1 ：支持的谓词下推列表"，这一句描述略显缀余。