### PR TITLE
[Communtiy-P1] SHOW DYNAMIC PARTITION TABLES 执行结果与文档描述不符

### DIFF
--- a/sql-reference/sql-statements/data-manipulation/SHOW DYNAMIC PARTITION TABLES.md
+++ b/sql-reference/sql-statements/data-manipulation/SHOW DYNAMIC PARTITION TABLES.md
@@ -2,7 +2,7 @@
 
 ## 功能
 
-该语句用于展示当前数据库 db 下所有的动态分区表状态。
+该语句用于展示当前数据库 db 下所有设置过动态分区属性的分区表状态。
 
 ## 语法
 
@@ -12,7 +12,7 @@ SHOW DYNAMIC PARTITION TABLES [FROM db_name];
 
 ## 示例
 
-1. 展示数据库 database 的所有动态分区表状态。
+1. 展示数据库 database 的所有设置过动态分区属性的分区表状态。
 
 ```sql
 SHOW DYNAMIC PARTITION TABLES FROM database;


### PR DESCRIPTION
执行语句查询的结果与语句描述不符，查询的结果中有动态分区属性为false的分区表，即查询的结果为所有设置过动态分区属性的表，无论是现在的动态属性分区是否开启。