### PR TITLE
[Communtiy-P3] Delete PROPERTIES "storage_type" = "column" in the create table statement

### DIFF
--- a/using_starrocks/Bitmap_index.md
+++ b/using_starrocks/Bitmap_index.md
@@ -34,8 +34,7 @@ Bitmap 索引能够提高指定列的查询效率。如果一个查询条件命�
     )
     ENGINE = olap
     AGGREGATE KEY(k1, k2)
-    DISTRIBUTED BY HASH(k1) BUCKETS 10
-    PROPERTIES ("storage_type" = "column");
+    DISTRIBUTED BY HASH(k1) BUCKETS 10;
     ```
 
     其中有关索引部分参数说明如下：


### PR DESCRIPTION
删除建表语句中的PROPERTIES ("storage_type" = "column")。该属性添加后虽然建表不报错，但是StarRocks中实际并不支持手动配置存储方式为行存列存，默认即为列存，此外也没有其他地方介绍过这个属性，为避免引起读者误解，建议删除。文档中其他发现有该参数的地方，稍后也逐个提PR。