### PR TITLE
[Community-P2] Delete the operation of opening the CBO optimizer

### DIFF
--- a/using_starrocks/Lateral_join.md
+++ b/using_starrocks/Lateral_join.md
@@ -11,11 +11,7 @@
 
 ## 开启 CBO 优化器
 
-使用 Lateral Join 功能前，您需要开启 CBO 优化器。
-
-~~~SQL
-SET global enable_cbo = true;
-~~~
+StarRocks 2.4 版本已集成并启用 CBO 优化器，您无需进行额外操作。
 
 ## 使用 Lateral Join
 


### PR DESCRIPTION
删除开启CBO优化器的操作。2.4版本的系统变量中已经没有enable_cbo这一项，默认集成且启用了CBO优化器，已无法手动关闭，这步操作已没有意义。