### PR TITLE
Update hive_catalog.md

### DIFF
--- a/data_source/catalog/hive_catalog.md
+++ b/data_source/catalog/hive_catalog.md
@@ -16,7 +16,7 @@ Hive Catalog 是一种 External Catalog。通过 Hive Catalog，您不需要执�
   - Parquet 文件支持 SNAPPY、LZ4、ZSTD、GZIP 和 NO_COMPRESSION 压缩格式。
   - ORC 文件支持 ZLIB、SNAPPY、LZO、LZ4、ZSTD 和 NO_COMPRESSION 压缩格式。
 
-- StarRocks 查询 Hive 数据时，不支持 INTERVAL、BINARY 和 UNION 三种数据类型。此外，对于 CSV 格式的 Hive 表，StarRocks 不支持 MAP 数据类型。
+- StarRocks 查询 Hive 数据时，不支持 INTERVAL、BINARY 和 UNION 三种数据类型。此外，对于 CSV 格式的 Hive 表，StarRocks 从 2.5 版本开始支持 MAP、STRUCT 数据类型。
 - Hive Catalog 仅支持查询 Hive 数据，不支持针对 Hive 的写/删操作。
 
 ## 准备工作


### PR DESCRIPTION
使用说明中：StarRocks 不支持 MAP 数据类型 改为  StarRocks 从 2.5 版本开始支持 MAP、STRUCT 数据类型