### PR TITLE
check links

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -25,6 +25,7 @@ jobs:
       if: always()
       uses: lycheeverse/lychee-action@v1.8.0
       with:
+        fail: true
         args: >
             --config ./lychee.toml
             --offline "./**/*.md"

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -25,4 +25,4 @@ jobs:
       if: always()
       uses: lycheeverse/lychee-action@v1.8.0
       with:
-        args: --offline --no-progress '**/*\.md*'
+        args: --offline --no-progress '**/*.md*'

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -21,3 +21,8 @@ jobs:
       if: always()
       run: |
         npx docusaurus-mdx-checker
+    - name: link check
+      if: always()
+      uses: lycheeverse/lychee-action@v1.8.0
+      with:
+        args: --offline --no-progress '**/*\.md*'

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -25,4 +25,6 @@ jobs:
       if: always()
       uses: lycheeverse/lychee-action@v1.8.0
       with:
-        args: exclude_path = ["./introduction/StarRocks_intro.md", "./assets"] --offline --no-progress '**/*.md*'
+        args: >
+            --config ./lychee.toml
+            --offline "./**/*.md"

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -25,4 +25,4 @@ jobs:
       if: always()
       uses: lycheeverse/lychee-action@v1.8.0
       with:
-        args: --offline --no-progress '**/*.md*'
+        args: exclude_path = ["./introduction/StarRocks_intro.md", "./assets"] --offline --no-progress '**/*.md*'

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+introduction/StarRocks_intro.md

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,0 @@
-introduction/StarRocks_intro.md

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,101 @@
+#############################  Display  #############################
+
+# Verbose program output
+# Accepts log level: "error", "warn", "info", "debug", "trace"
+verbose = "info"
+
+# Show progress
+progress = true
+
+# Path to summary output file.
+# output = "report.md"
+
+#############################  Cache  ###############################
+
+# Enable link caching. This can be helpful to avoid checking the same links on
+# multiple runs.
+cache = true
+
+# Discard all cached requests older than this duration.
+max_cache_age = "2d"
+
+#############################  Runtime  #############################
+
+# Number of threads to utilize.
+# Defaults to number of cores available to the system if omitted.
+threads = 6
+
+# Maximum number of allowed redirects [default: 10]
+max_redirects = 10
+
+# Maximum number of concurrent network requests [default: 128]
+max_concurrency = 30
+
+#############################  Requests  ############################
+
+# User agent to send with each request
+user_agent = "curl/7.83.1"
+
+# Website timeout from connect to response finished
+timeout = 10
+
+# Comma-separated list of accepted status codes for valid links.
+# Omit to accept all response types.
+#accept = "text/html"
+
+# Proceed for server connections considered insecure (invalid TLS)
+insecure = false
+
+# Comma-separated list of accepted status codes for valid links.
+accept = [200, 204, 301, 429]
+
+# Only test links with the given schemes (e.g. https).
+# Omit to check links with any scheme.
+scheme = [ "https" ]
+
+# When links are available using HTTPS, treat HTTP links as errors.
+require_https = true
+
+# Request method
+method = "get"
+
+# Custom request headers
+headers = []
+
+# Remap URI matching pattern to different URI.
+# remap = [ "https://example.com http://example.invalid" ]
+
+
+#############################  Exclusions  ##########################
+
+# Exclude URLs from checking (supports regex)
+
+# exclude = [
+#   "https://bob:secret@proxy.company.com:12345",
+#   "https://github.com/balena-io/balena-cli/releases/download/*",
+#   "file://*",
+#   "system@*",
+#   ]
+
+# Exclude these filesystem paths from getting checked.
+exclude_path = ["./README.md", "./introduction/StarRocks_intro.md", "./assets/"]
+
+include = []
+
+include_verbatim = true
+
+# Exclude all private IPs from checking
+# Equivalent to setting `exclude_private`, `exclude_link_local`, and `exclude_loopback` to true
+exclude_all_private = true
+
+# # Exclude private IP address ranges from checking
+# exclude_private = false
+
+# # Exclude link-local IP address range from checking
+# exclude_link_local = false
+
+# # Exclude loopback IP address range and localhost from checking
+# exclude_loopback = false
+
+# Exclude all mail addresses from checking
+exclude_mail = true

--- a/lychee.toml
+++ b/lychee.toml
@@ -14,19 +14,21 @@ progress = true
 
 # Enable link caching. This can be helpful to avoid checking the same links on
 # multiple runs.
-cache = true
+# If we start checking external links we should enable this, but at the
+# moment we are checking links to Markdown files only with arg --offline
+cache = false
 
 # Discard all cached requests older than this duration.
-max_cache_age = "2d"
+# max_cache_age = "2d"
 
 #############################  Runtime  #############################
 
 # Number of threads to utilize.
 # Defaults to number of cores available to the system if omitted.
-threads = 6
+# threads = 6
 
 # Maximum number of allowed redirects [default: 10]
-max_redirects = 10
+# max_redirects = 10
 
 # Maximum number of concurrent network requests [default: 128]
 max_concurrency = 30
@@ -78,6 +80,10 @@ headers = []
 #   ]
 
 # Exclude these filesystem paths from getting checked.
+# We exclude StarRocks_intro as it generates the URLs
+# via a component that takes the path without the `.md`
+# extension, and lychee is looking for a valid path
+# including extension.
 exclude_path = ["./README.md", "./introduction/StarRocks_intro.md", "./assets/"]
 
 include = []


### PR DESCRIPTION
Adds a link checker to the linting workflow. For the moment this is checking only Markdown links to local Markdown files. Once we have all of those fixed we can expand to external links.