### PR TITLE
Update iceberg_catalog.md

### DIFF
--- a/data_source/catalog/iceberg_catalog.md
+++ b/data_source/catalog/iceberg_catalog.md
@@ -489,7 +489,7 @@ PROPERTIES
 (
     "type" = "iceberg",
     "iceberg.catalog.type" = "hive",
-    "hive.metastore.uris" = "thrift://xx.xx.xx:9083"
+    "iceberg.catalog.hive.metastore.uris" = "thrift://xx.xx.xx:9083"
 );
 ```
 


### PR DESCRIPTION
if you use HDFS as the storage, when you create the iceberg catalog, the metastore settings should be 
"iceberg.catalog.hive.metastore.uris" = "thrift://xx.xx.xx:9083"
not
"hive.metastore.uris" = "thrift://xx.xx.xx:9083"
otherwise you will get the error message:
"SQL 错误[1064][42000]:property iceberg.catlog.type is missing or not supported now."
